### PR TITLE
handle decode error

### DIFF
--- a/ch03/gmail/gmail_slurper.py
+++ b/ch03/gmail/gmail_slurper.py
@@ -134,7 +134,11 @@ class GmailSlurper(object):
         (status, email_hash, charset) = self.fetch_email(email_id)
         if(status == 'OK' and charset and 'thread_id' in email_hash and 'from' in email_hash):
           print email_id, charset, email_hash['thread_id']
-          self.write(email_hash)
+          try:
+            self.write(email_hash)
+          except UnicodeDecodeError, e:
+            sys.stderr.write("Error decode email id " + str(email_id) + ". error message: " + e.message)
+            continue
           if((int(email_id) % 1000) == 0):
             self.flush()
         elif(status == 'ERROR' or status == 'PARSE' or status == 'UNICODE' or status == 'CHARSET' or status =='FROM'):

--- a/ch03/gmail/gmail_slurper.py
+++ b/ch03/gmail/gmail_slurper.py
@@ -138,7 +138,6 @@ class GmailSlurper(object):
             self.write(email_hash)
           except UnicodeDecodeError, e:
             sys.stderr.write("Error decode email id " + str(email_id) + ". error message: " + e.message)
-            continue
           if((int(email_id) % 1000) == 0):
             self.flush()
         elif(status == 'ERROR' or status == 'PARSE' or status == 'UNICODE' or status == 'CHARSET' or status =='FROM'):


### PR DESCRIPTION
There is a decode error, we should catch it, otherwise the program will abort.

```
Traceback (most recent call last):
  File "./gmail.py", line 104, in <module>
    main()
  File "./gmail.py", line 98, in main
    slurper.slurp() 
  File "/home/jj/Workspaces/hadoop/Agile_Data_Code/ch03/gmail/gmail_slurper.py", line 137, in slurp
    self.write(email_hash)
  File "/home/jj/Workspaces/hadoop/Agile_Data_Code/ch03/gmail/gmail_slurper.py", line 125, in write
    self.avro_writer.append(record)
  File "/usr/local/lib/python2.7/dist-packages/avro/datafile.py", line 196, in append
    self.datum_writer.write(datum, self.buffer_encoder)
  File "/usr/local/lib/python2.7/dist-packages/avro/io.py", line 771, in write
    self.write_data(self.writers_schema, datum, encoder)
  File "/usr/local/lib/python2.7/dist-packages/avro/io.py", line 802, in write_data
    self.write_record(writers_schema, datum, encoder)
  File "/usr/local/lib/python2.7/dist-packages/avro/io.py", line 890, in write_record
    self.write_data(field.type, datum.get(field.name), encoder)
  File "/usr/local/lib/python2.7/dist-packages/avro/io.py", line 802, in write_data
    self.write_record(writers_schema, datum, encoder)
  File "/usr/local/lib/python2.7/dist-packages/avro/io.py", line 890, in write_record
    self.write_data(field.type, datum.get(field.name), encoder)
  File "/usr/local/lib/python2.7/dist-packages/avro/io.py", line 800, in write_data
    self.write_union(writers_schema, datum, encoder)
  File "/usr/local/lib/python2.7/dist-packages/avro/io.py", line 880, in write_union
    self.write_data(writers_schema.schemas[index_of_schema], datum, encoder)
  File "/usr/local/lib/python2.7/dist-packages/avro/io.py", line 780, in write_data
    encoder.write_utf8(datum)
  File "/usr/local/lib/python2.7/dist-packages/avro/io.py", line 356, in write_utf8
    datum = datum.encode("utf-8")
UnicodeDecodeError: 'ascii' codec can't decode byte 0xcc in position 0: ordinal not in range(128)
```
